### PR TITLE
feat: Implement dynamic font size for dimension text

### DIFF
--- a/css/components/visualization.css
+++ b/css/components/visualization.css
@@ -108,7 +108,7 @@ circle.antenna-tooth:hover {
 
 .dimension-text {
     fill: var(--text-secondary);
-    font-size: 0.75rem;
+    /* font-size: 0.75rem; */ /* Font size is now set dynamically via JavaScript */
     font-family: var(--font-mono);
     text-anchor: middle;
     -webkit-user-select: none;


### PR DESCRIPTION
The font size for `.dimension-text` in the SVG visualization is now dynamically calculated based on the overall antenna size.

Previously, the font size was fixed at 0.75rem. This change updates `js/modules/visualization.js` to:
1. Calculate the actual maximum radius of the antenna in meters.
2. Determine the desired font size as 5% of this maximum radius. The font size is converted to millimeters (SVG user units).
3. Apply this calculated font size directly to the `font-size` attribute of the SVG text elements with the class `.dimension-text`.

The fixed `font-size` was removed from the
`css/components/visualization.css` for the `.dimension-text` class to allow the SVG attribute to take precedence.

For example, if the largest radius of the calculated antenna is 0.26m, the dimension text font size will be set to 13 (representing 0.013m or 13mm).