### PR TITLE
feat: Add radii labels to antenna visualization

### DIFF
--- a/css/components/visualization.css
+++ b/css/components/visualization.css
@@ -115,6 +115,11 @@ circle.antenna-tooth:hover {
     user-select: none;
 }
 
+.radius-label {
+    fill: #007bff; /* Distinct blue color for radius labels */
+    dominant-baseline: middle; /* Align text vertically to the middle of its x,y coordinates */
+}
+
 /* Grid Lines */
 .grid-line {
     stroke: var(--border-color);


### PR DESCRIPTION
I've implemented a new function `addRadiiLabels` in `visualization.js` to display labels for specific radii on the antenna diagram.

Key changes:
- I created `addRadiiLabels` which generates SVG text elements for given radii, positioning them at a specified angle and offset.
- Labels use a dynamic font size and have a distinct style (`.radius-label`).
- I modified `drawReferenceLines` to call `addRadiiLabels`. It selects the first, last, and up to two intermediate radii for labeling.
- I added CSS for `.radius-label` to set a blue color and improve vertical alignment.

This enhancement improves the readability of the antenna visualization by providing clear dimensioning for key radial parameters.